### PR TITLE
Trace HTTP requests with Datadog if available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gemspec
 
 group :development, :test do
   gem 'pry', '~> 0.14'
+  gem 'pry-rescue'
+  gem 'pry-stack_explorer'
   gem 'rake', '~> 13.0'
   gem 'rspec', '~> 3.0'
   gem 'rspec_junit_formatter', '~> 0.6'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ config = NetSuite::Configuration.new(
   ),
   logger: Rails.logger,
   log_requests: true,
-  trace_requests: true,
+  datadog_request_tracing: true,
   request_timeout: 30,
 )
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ config = NetSuite::Configuration.new(
   ),
   logger: Rails.logger,
   log_requests: true,
+  trace_requests: true,
   request_timeout: 30,
 )
 ```

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -53,7 +53,7 @@ module NetSuite
     attr_accessor :retry_count
 
     def trace_call(method, url, request_payload, *_args, &)
-      return yield unless trace_requests?
+      return yield unless datadog_request_tracing?
 
       ::Datadog::Tracing.trace("netsuite #{method}",
                                resource: "#{method} #{url}",
@@ -109,8 +109,8 @@ module NetSuite
       config.logger && config.log_requests?
     end
 
-    def trace_requests?
-      defined?(::Datadog::Tracing.trace) && config.trace_requests?
+    def datadog_request_tracing?
+      defined?(::Datadog::Tracing.trace) && config.datadog_request_tracing?
     end
 
     def build_connection

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -53,7 +53,7 @@ module NetSuite
     attr_accessor :retry_count
 
     def trace_call(method, url, request_payload, *_args, &)
-      return yield unless defined?(::Datadog::Tracing.trace)
+      return yield unless trace_requests?
 
       ::Datadog::Tracing.trace("netsuite #{method}",
                                resource: "#{method} #{url}",
@@ -107,6 +107,10 @@ module NetSuite
 
     def log_requests?
       config.logger && config.log_requests?
+    end
+
+    def trace_requests?
+      defined?(::Datadog::Tracing.trace) && config.trace_requests?
     end
 
     def build_connection

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -56,11 +56,11 @@ module NetSuite
       return yield unless datadog_request_tracing?
 
       Datadog::Tracing.trace("netsuite #{method}",
-                               resource: "#{method} #{url}",
-                               span_type: 'http',
-                               service: 'netsuite',
-                               tags: { method:, url:, request_payload: },
-                               &)
+                             resource: "#{method} #{url}",
+                             span_type: 'http',
+                             service: 'netsuite',
+                             tags: { method:, url:, request_payload: },
+                             &)
     end
 
     def with_auth_retry(&)

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -55,7 +55,7 @@ module NetSuite
     def trace_call(method, url, request_payload, &)
       return yield unless datadog_request_tracing?
 
-      ::Datadog::Tracing.trace("netsuite #{method}",
+      Datadog::Tracing.trace("netsuite #{method}",
                                resource: "#{method} #{url}",
                                span_type: 'http',
                                service: 'netsuite',
@@ -110,7 +110,7 @@ module NetSuite
     end
 
     def datadog_request_tracing?
-      defined?(::Datadog::Tracing.trace) && config.datadog_request_tracing?
+      defined?(Datadog::Tracing.trace) && config.datadog_request_tracing?
     end
 
     def build_connection

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -58,13 +58,7 @@ module NetSuite
         span_type: 'http',
         service: 'netsuite',
         tags: { method: method, url: url, request_payload: request_payload },
-        &block).tap { send_metric(method, started) }
-    end
-
-    def send_metric(method, started)
-      ended = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-      $stats.distribution('net_suite.timing', ended - started, tags: { method: method })
+        &block)
     end
 
     def with_auth_retry(&)

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -48,17 +48,17 @@ module NetSuite
 
     attr_accessor :retry_count
 
-    def trace_call(method, url, request_payload, *args, &block)
+    def trace_call(method, url, request_payload, *_args, &)
       return yield unless defined?(::Datadog::Tracing.trace)
 
       started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       ::Datadog::Tracing.trace("netsuite #{method}",
-        resource: "#{method} #{url}",
-        span_type: 'http',
-        service: 'netsuite',
-        tags: { method: method, url: url, request_payload: request_payload },
-        &block)
+                               resource: "#{method} #{url}",
+                               span_type: 'http',
+                               service: 'netsuite',
+                               tags: { method:, url:, request_payload: },
+                               &)
     end
 
     def with_auth_retry(&)

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -52,7 +52,7 @@ module NetSuite
 
     attr_accessor :retry_count
 
-    def trace_call(method, url, request_payload, *_args, &)
+    def trace_call(method, url, request_payload, &)
       return yield unless datadog_request_tracing?
 
       ::Datadog::Tracing.trace("netsuite #{method}",

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -12,7 +12,9 @@ module NetSuite
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         # def get(url = nil, params = nil, headers = nil)
         #   with_auth_retry do
-        #     connection.get(url, params, headers)
+        #     trace_call(__method__.to_s.upcase, url, nil) do
+        #       connection.get(url, params, headers)
+        #     end
         #   end
         # end
 
@@ -30,7 +32,9 @@ module NetSuite
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         # def post(url = nil, body = nil, headers = nil, &block)
         #   with_auth_retry do
-        #     connection.post(url, body, headers, &block)
+        #     trace_call(__method__.to_s.upcase, url, body) do
+        #       connection.post(url, body, headers, &block)
+        #     end
         #   end
         # end
 

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -59,7 +59,7 @@ module NetSuite
                              resource: "#{method} #{url}",
                              span_type: 'http',
                              service: 'netsuite',
-                             tags: { method:, url:, request_payload: },
+                             tags: { method:, url:, request_payload:, async: async? },
                              &)
     end
 
@@ -111,6 +111,10 @@ module NetSuite
 
     def datadog_request_tracing?
       defined?(Datadog::Tracing.trace) && config.datadog_request_tracing?
+    end
+
+    def async?
+      defined?(Sidekiq.server?) && Sidekiq.server?
     end
 
     def build_connection

--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -51,8 +51,6 @@ module NetSuite
     def trace_call(method, url, request_payload, *_args, &)
       return yield unless defined?(::Datadog::Tracing.trace)
 
-      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
       ::Datadog::Tracing.trace("netsuite #{method}",
                                resource: "#{method} #{url}",
                                span_type: 'http',

--- a/lib/net_suite/configuration.rb
+++ b/lib/net_suite/configuration.rb
@@ -8,11 +8,13 @@ module NetSuite
       :logger!,
       {
         log_requests: false,
+        trace_requests: false,
         request_timeout: 120,
       },
     ]
 
     alias log_requests? log_requests
+    alias trace_requests? trace_requests
 
     class OAuth
       rattr_initialize [

--- a/lib/net_suite/configuration.rb
+++ b/lib/net_suite/configuration.rb
@@ -8,13 +8,13 @@ module NetSuite
       :logger!,
       {
         log_requests: false,
-        trace_requests: false,
+        datadog_request_tracing: false,
         request_timeout: 120,
       },
     ]
 
     alias log_requests? log_requests
-    alias trace_requests? trace_requests
+    alias datadog_request_tracing? datadog_request_tracing
 
     class OAuth
       rattr_initialize [

--- a/spec/net_suite/client_spec.rb
+++ b/spec/net_suite/client_spec.rb
@@ -9,6 +9,7 @@ describe NetSuite::Client do
       restlet: restlet_config,
       logger:,
       log_requests:,
+      trace_requests:,
       request_timeout:,
     )
   end
@@ -43,6 +44,7 @@ describe NetSuite::Client do
   end
 
   let(:log_requests) { true }
+  let(:trace_requests) { true }
   let(:request_timeout) { 30 }
 
   let(:path) { '/some_path' }

--- a/spec/net_suite/client_spec.rb
+++ b/spec/net_suite/client_spec.rb
@@ -9,7 +9,7 @@ describe NetSuite::Client do
       restlet: restlet_config,
       logger:,
       log_requests:,
-      trace_requests:,
+      datadog_request_tracing:,
       request_timeout:,
     )
   end
@@ -44,7 +44,7 @@ describe NetSuite::Client do
   end
 
   let(:log_requests) { true }
-  let(:trace_requests) { true }
+  let(:datadog_request_tracing) { true }
   let(:request_timeout) { 30 }
 
   let(:path) { '/some_path' }

--- a/spec/net_suite/configuration_spec.rb
+++ b/spec/net_suite/configuration_spec.rb
@@ -58,20 +58,20 @@ describe NetSuite::Configuration do
       end
     end
 
-    describe 'trace_requests' do
-      context 'when trace_requests is missing' do
+    describe 'datadog_request_tracing' do
+      context 'when datadog_request_tracing is missing' do
         subject { described_class.new(oauth:, restlet:, logger:) }
 
         it 'is configured with false as default' do
-          expect(subject.trace_requests).to eq(false)
+          expect(subject.datadog_request_tracing).to eq(false)
         end
       end
 
-      context 'when trace_requests is included' do
-        subject { described_class.new(oauth:, restlet:, logger:, trace_requests: :something) }
+      context 'when datadog_request_tracing is included' do
+        subject { described_class.new(oauth:, restlet:, logger:, datadog_request_tracing: :something) }
 
         it 'is configured with the provided value' do
-          expect(subject.trace_requests).to eq(:something)
+          expect(subject.datadog_request_tracing).to eq(:something)
         end
       end
     end

--- a/spec/net_suite/configuration_spec.rb
+++ b/spec/net_suite/configuration_spec.rb
@@ -58,6 +58,24 @@ describe NetSuite::Configuration do
       end
     end
 
+    describe 'trace_requests' do
+      context 'when trace_requests is missing' do
+        subject { described_class.new(oauth:, restlet:, logger:) }
+
+        it 'is configured with false as default' do
+          expect(subject.trace_requests).to eq(false)
+        end
+      end
+
+      context 'when trace_requests is included' do
+        subject { described_class.new(oauth:, restlet:, logger:, trace_requests: :something) }
+
+        it 'is configured with the provided value' do
+          expect(subject.trace_requests).to eq(:something)
+        end
+      end
+    end
+
     describe 'request_timeout' do
       context 'when request_timeout is missing' do
         subject { described_class.new(oauth:, restlet:, logger:) }


### PR DESCRIPTION
This is inspired by the tracing done in https://github.com/careofvitamins/fc/blob/74c86ea1ac0716f529452dde8faf469e4f90b575/wms/app/adapters/data_ninja/api.rb#L63-L74,
see more context at https://github.com/careofvitamins/fc/pull/2328#pullrequestreview-1165972377

Shortcut story: https://app.shortcut.com/careof/story/13776/add-datadog-apm-tracing-to-net-suite-gem