### PR TITLE
Support for configuring log_level

### DIFF
--- a/lib/net_suite/client.rb
+++ b/lib/net_suite/client.rb
@@ -125,8 +125,20 @@ module NetSuite
         conn.request :authorization, 'Bearer', -> { fetch_auth_token }
         conn.response :json, content_type: /\bjson$/
 
-        conn.response :logger, config.logger, headers: true, bodies: true if log_requests?
+        configure_logging(conn)
       end
+    end
+
+    def configure_logging(connection)
+      return unless log_requests?
+
+      connection.response(
+        :logger,
+        config.logger,
+        headers: true,
+        bodies: true,
+        log_level: config.log_level,
+      )
     end
   end
 end

--- a/lib/net_suite/configuration.rb
+++ b/lib/net_suite/configuration.rb
@@ -7,6 +7,7 @@ module NetSuite
       :restlet!,
       :logger!,
       {
+        log_level: :info,
         log_requests: false,
         datadog_request_tracing: false,
         request_timeout: 120,

--- a/spec/net_suite/client_spec.rb
+++ b/spec/net_suite/client_spec.rb
@@ -15,7 +15,7 @@ describe NetSuite::Client do
   end
 
   let(:oauth_config) do
-    ::NetSuite::Configuration::OAuth.new(
+    NetSuite::Configuration::OAuth.new(
       api_host: 'http://oauth.example.com',
       client_id: 'a_client_id',
       certificate_id: 'aaaaaaaaaaaa',

--- a/spec/net_suite/configuration_spec.rb
+++ b/spec/net_suite/configuration_spec.rb
@@ -58,6 +58,24 @@ describe NetSuite::Configuration do
       end
     end
 
+    describe 'log_level' do
+      context 'when log_level is missing' do
+        subject { described_class.new(oauth:, restlet:, logger:) }
+
+        it 'is configured with :info as default' do
+          expect(subject.log_level).to eq(:info)
+        end
+      end
+
+      context 'when log_level is included' do
+        subject { described_class.new(oauth:, restlet:, logger:, log_level: :warn) }
+
+        it 'is configured with the provided value' do
+          expect(subject.log_level).to eq(:warn)
+        end
+      end
+    end
+
     describe 'datadog_request_tracing' do
       context 'when datadog_request_tracing is missing' do
         subject { described_class.new(oauth:, restlet:, logger:) }


### PR DESCRIPTION
Adds ability to configure request logging level, while keeping the default of `info`.